### PR TITLE
Update ledger.py

### DIFF
--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -1582,6 +1582,7 @@ class LedgerPlugin(HW_PluginBase):
         0x40: "Ledger Nano X",
         0x50: "Ledger Nano S Plus",
         0x60: "Ledger Stax",
+        0x70: "Ledger Flex",
     }
 
     SUPPORTED_XTYPES = ("standard",)  #'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')


### PR DESCRIPTION
This is to fix the problem with the RavenCoin App on the Ledger Flex not being recognized as a piece of Leger Hardware for the Hardware Wallet option.

Now you just have to plug in your Leger Flex (with Ledger Live closed) and unlock and run the RavenCoin app on the Ledger Flex device (which you download from the Ledger Live app first) and it will recognize it as a valid Ledger Device and allow you to access your new or preexisting wallet (from another Ledger Device like the Nano X if using the same security key as the last wallet).

I asked Ledger to look into the Flex not being compatible with this software wallet, even though they have it in their app for download to the Flex. In the end I figured out the problem and fixed it for all to enjoy without any help from Ledger (no credit goes to them lol).

I hope everyone enjoys being able to use their Flex Wallet now ;)